### PR TITLE
[MRG] Fix decoding PersonName in convert_PN

### DIFF
--- a/pydicom/tests/test_values.py
+++ b/pydicom/tests/test_values.py
@@ -245,6 +245,15 @@ class TestConvertPN:
         converted_string = convert_PN(bytestring, ['latin_1', 'iso2022_jp'])
         assert 'Sunatouge^Ayano=砂峠^綾能' == converted_string
 
+    def test_multi_value(self):
+        """Test that backslash is handled as value separator"""
+        bytestring = (b'Buc^J\xe9r\xf4me\\\x1b\x2d\x46'
+                      b'\xc4\xe9\xef\xed\xf5\xf3\xe9\xef\xf2\\'
+                      b'\x1b$BG\\<\\\x1b(B^\x1b$BK\\L\\')
+        encodings = ['latin_1', 'iso2022_jp', 'iso_ir_126']
+        assert ['Buc^Jérôme', 'Διονυσιος', '倍尺^本目'] == convert_PN(
+            bytestring, encodings)
+
 
 def test_all_converters():
     """Test that the VR decoder functions are complete"""

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -463,17 +463,14 @@ def convert_PN(
 
     Returns
     -------
-    valuerep.PersonName or MultiValue of PersonName
-        The decoded 'PN' value(s).
+    valuerep.PersonName
+        The decoded 'PN' value.
     """
-    def get_valtype(x: bytes) -> PersonName:
-        return PersonName(x, encodings).decode()
 
-    b_split = byte_string.rstrip(b'\x00 ').split(b'\\')
-    if len(b_split) == 1:
-        return get_valtype(b_split[0])
-
-    return MultiValue(get_valtype, b_split)
+    encodings = encodings or [default_encoding]
+    stripped_string = byte_string.rstrip(b'\x00 ')
+    decoded_value = decode_bytes(stripped_string, encodings, TEXT_VR_DELIMS)
+    return PersonName(decoded_value, encodings, stripped_string).decode()
 
 
 def convert_string(

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -463,14 +463,25 @@ def convert_PN(
 
     Returns
     -------
-    valuerep.PersonName
-        The decoded 'PN' value.
+    valuerep.PersonName or MultiValue of PersonName
+        The decoded 'PN' value(s).
     """
 
     encodings = encodings or [default_encoding]
+
+    def get_valtype(x: str) -> PersonName:
+        person_name = PersonName(x, encodings)
+        # Using an already decoded string in PersonName constructor leaves
+        # the original string as undefined, let's set it through encode
+        person_name.encode()
+        return person_name.decode()
+
     stripped_string = byte_string.rstrip(b'\x00 ')
     decoded_value = decode_bytes(stripped_string, encodings, TEXT_VR_DELIMS)
-    return PersonName(decoded_value, encodings, stripped_string).decode()
+    value_splitted = decoded_value.split('\\')
+    if len(value_splitted) == 1:
+        return get_valtype(value_splitted[0])
+    return MultiValue(get_valtype, value_splitted)
 
 
 def convert_string(


### PR DESCRIPTION
#### Describe the changes
This is an addon to the PR #1724 to fix decoding PersonName tags in multibyte characters that contain backslash (0x5C) in their codes (e.g. 倍 in Japanese).
It appears that the [PersonName type shall not contain backslashes](https://dicom.nema.org/dicom/2013/output/chtml/part05/sect_6.2.html).
Thanks @ykszk for your work :pray: 

#### Tasks
- [x] Unit tests added that reproduce the issue or prove feature is working
- [x] Fix or feature added
- [x] Code typed and mypy shows no errors
- [ ] Documentation updated (if relevant)
  - [ ] No warnings during build
  - [ ] Preview link (CircleCI -> Artifacts -> `doc/_build/html/index.html`)
- [x] Unit tests passing and overall coverage the same or better
